### PR TITLE
Added option to use a command prefix & other minor fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { TitleBar } from "./components/TitleBar";
 
 import { MantineProvider } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
+import { platform } from '@tauri-apps/plugin-os';
 import SettingsModal from "./components/SettingsModal";
 import Play from "./components/Play";
 import { useAutoUpdater } from "./hooks/useAutoUpdater";
@@ -30,6 +31,8 @@ function App() {
     }
   }, []);
 
+  const noAnimation = () => { if(platform() === "linux") return true; }
+
   return (
     <MantineProvider>
       <SettingsModal opened={opened} close={close} />
@@ -38,7 +41,7 @@ function App() {
         <div className="absolute inset-0 overflow-hidden z-0">
           {/* Zoomed + Animated Background */}
           <div
-            className="w-full h-full bg-cover animate-pulse-slow"
+            className={`w-full h-full bg-cover` + (noAnimation() ?? " animate-pulse-slow")}
             style={{
               backgroundImage: "url('/background.jpg')",
               backgroundPosition: "top right",

--- a/src/components/LinuxTab.tsx
+++ b/src/components/LinuxTab.tsx
@@ -2,25 +2,27 @@ import { Group } from "@mantine/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useSettings } from "../hooks/useSettings"; // Adjust path as needed
 import Button from "./Button";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { LauncherSettings } from "../types/settings";
 
 function LinuxTab() {
   const { settings, setSettings } = useSettings();
+  const [cmdPrefix, setCmdPrefix] = useState("");
 
   useEffect(() => {
     const trySyncSavePath = async () => {
-      const { winePrefix, wineRunner } = settings.linux;
+      const { winePrefix, wineRunner, commandPrefix } = settings.linux;
 
-      if (!winePrefix || !wineRunner) return;
+      setCmdPrefix(settings.linux.commandPrefix || "");
+
+      if (!winePrefix || !wineRunner || !commandPrefix) return;
     };
 
     trySyncSavePath();
-  }, [settings.linux.winePrefix, settings.linux.wineRunner]);
+  }, [settings.linux.winePrefix, settings.linux.wineRunner, settings.linux.commandPrefix]);
 
   const gameDir = settings.preferences.gameDirectory;
-  const wineDir = settings.linux.winePrefix;
-  const wineRun = settings.linux.wineRunner;
+  const linuxSettings = settings.linux;
 
   const handleChangeDirectory = async (
     key: keyof LauncherSettings["linux"]
@@ -41,7 +43,19 @@ function LinuxTab() {
     }
   };
 
-  const handleClearDirectory = async (
+  const handleCommandPrefix = async (
+    key: keyof LauncherSettings["linux"]
+  ) => {
+    setSettings((prev) => ({
+        ...prev,
+        linux: {
+          ...prev.linux,
+          [key]: cmdPrefix,
+        },
+      }));
+  };
+
+  const handleClearFormField = async (
     key: keyof LauncherSettings["linux"]
   ) => {
       setSettings((prev) => ({
@@ -73,7 +87,7 @@ function LinuxTab() {
         </p>
         <input
           type="text"
-          value={wineDir}
+          value={linuxSettings.winePrefix}
           readOnly
           className="w-200 px-3 py-2 bg-black/40 text-white/60 rounded border-2 border-black/20 text-sm focus:outline-none cursor-default"
         />
@@ -88,7 +102,7 @@ function LinuxTab() {
           </Button>
           <Button
             color="white"
-            onClick={() => handleClearDirectory("winePrefix")}
+            onClick={() => handleClearFormField("winePrefix")}
           >
             Clear
           </Button>
@@ -101,7 +115,7 @@ function LinuxTab() {
         </p>
         <input
           type="text"
-          value={wineRun}
+          value={linuxSettings.wineRunner}
           readOnly
           className="w-200 px-3 py-2 bg-black/40 text-white/60 rounded border-2 border-black/20 text-sm focus:outline-none cursor-default"
         />
@@ -116,7 +130,35 @@ function LinuxTab() {
           </Button>
           <Button
             color="white"
-            onClick={() => handleClearDirectory("wineRunner")}
+            onClick={() => handleClearFormField("wineRunner")}
+          >
+            Clear
+          </Button>
+        </Group>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        <p className="text-white/80 font-semibold text-xl">
+          Command Prefix <i>(Optional)</i>
+        </p>
+        <input
+          type="text"
+          value={cmdPrefix}
+          onChange={(e) => setCmdPrefix(e.target.value)}
+          className="w-200 px-3 py-2 bg-black/40 text-white/60 rounded border-2 border-black/20 text-sm focus:outline-none"
+        />
+
+        <Group gap="sm">
+          <Button
+            disabled={settings.preferences.gameDirectory === ""}
+            color="white"
+            onClick={() => handleCommandPrefix("commandPrefix")}
+          >
+            Save
+          </Button>
+          <Button
+            color="white"
+            onClick={() => handleClearFormField("commandPrefix")}
           >
             Clear
           </Button>

--- a/src/components/Play.tsx
+++ b/src/components/Play.tsx
@@ -33,8 +33,7 @@ function Play() {
       const currentPlatform = platform();
       const loadedSettings = await loadSettings();
       const gameDir = loadedSettings.preferences.gameDirectory;
-      const wineDir = loadedSettings.linux.winePrefix;
-      const wineBin = loadedSettings.linux.wineRunner;
+      const linuxSettings = loadedSettings.linux;
       console.log("Using gameDirectory:", gameDir);
       console.log("currentPlatform:", currentPlatform);
 
@@ -72,8 +71,8 @@ function Play() {
       }
 
       // Check for a Wine binary if there's a Winerunner directory selected
-      if(currentPlatform === "linux" && wineBin) {
-        const winePath = await join(wineBin, "wine")
+      if(currentPlatform === "linux" && linuxSettings.wineRunner) {
+        const winePath = await join(linuxSettings.wineRunner, "wine")
         const wineExists = await exists(winePath);
 
         console.log("Wine binary exist at path?", winePath, wineExists);
@@ -90,11 +89,12 @@ function Play() {
 
       // Wine launch string
       const wineCommand = () => {
-        return "cd '"+gameDir+"' && "
-        +(wineDir ? 'WINEPREFIX=\''+wineDir+'\' ' : '')
-        +(wineBin ? '\''+wineBin+'/wine\'' : 'wine')+" './PlugY.exe'";
+        return "cd '"+gameDir+"' &&"
+        +(linuxSettings.winePrefix ? ' WINEPREFIX=\''+linuxSettings.winePrefix+'\'' : '')
+        +(linuxSettings.commandPrefix ? ' '+linuxSettings.commandPrefix : '')
+        +(linuxSettings.wineRunner ? ' \''+linuxSettings.wineRunner+'/wine\'' : ' wine')+" './PlugY.exe'";
       }
-      //console.log(wineCommand());
+      console.log(wineCommand());
 
       // Run bash command if your current platform is not Windows
       const command = currentPlatform !== "windows" ? 

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -28,6 +28,7 @@ const defaultSettings: LauncherSettings = {
   linux: {
     winePrefix: "",
     wineRunner: "",
+    commandPrefix: "",
   },
   game: {
     densityMultiplier: 1,

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -8,6 +8,7 @@ export type LauncherSettings = {
   linux: {
     winePrefix: string;
     wineRunner: string;
+    commandPrefix: string;
   };
   game: {
     densityMultiplier: number;

--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -15,6 +15,7 @@ const defaultSettings: LauncherSettings = {
   linux: {
     winePrefix: "",
     wineRunner: "",
+    commandPrefix: "",
   },
   game: {
     densityMultiplier: 1,


### PR DESCRIPTION
Added an input field to type a command to use before starting the winerunner for use with ex. wrappers like "gamemode"(power profile manager) and "mangohud"(linux version of MSI Afterburner).

Also removed the CSS class "animate-pulse-slow" for now on background-image since it spiked CPU usage to 95% and more on Linux. Probably because of lack of hardware acceleration with webkit2gtk.